### PR TITLE
feat(aws) Support enabling/disabling Auto Scaling Group metrics

### DIFF
--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/AutoScalingWorker.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.aws.deploy
 import com.amazonaws.services.autoscaling.model.CreateAutoScalingGroupRequest
+import com.amazonaws.services.autoscaling.model.EnableMetricsCollectionRequest
 import com.amazonaws.services.autoscaling.model.SuspendProcessesRequest
 import com.amazonaws.services.autoscaling.model.Tag
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
@@ -60,6 +61,7 @@ class AutoScalingWorker {
   private Boolean associatePublicIpAddress
   private String subnetType
   private Integer cooldown
+  private Collection<String> groupMetrics
   private Integer healthCheckGracePeriod
   private String healthCheckType
   private String spotPrice
@@ -216,6 +218,9 @@ class AutoScalingWorker {
     autoScaling.createAutoScalingGroup(request)
     if (suspendedProcesses) {
       autoScaling.suspendProcesses(new SuspendProcessesRequest(autoScalingGroupName: asgName, scalingProcesses: suspendedProcesses))
+    }
+    if (groupMetrics) {
+      autoScaling.enableMetricsCollection(new EnableMetricsCollectionRequest().withAutoScalingGroupName(asgName))
     }
     autoScaling.updateAutoScalingGroup(new UpdateAutoScalingGroupRequest(autoScalingGroupName: asgName,
       minSize: minInstances, maxSize: maxInstances, desiredCapacity: desiredInstances))

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/BasicAmazonDeployDescription.groovy
@@ -36,6 +36,7 @@ class BasicAmazonDeployDescription extends AbstractAmazonCredentialsDescription 
   String keyPair
   Boolean associatePublicIpAddress
   Integer cooldown
+  Collection<String> groupMetrics
   Integer healthCheckGracePeriod
   String healthCheckType
   String spotPrice

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyAsgDescription.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/description/ModifyAsgDescription.groovy
@@ -22,6 +22,7 @@ class ModifyAsgDescription extends AbstractAmazonCredentialsDescription {
   Integer cooldown
   Integer healthCheckGracePeriod
   String healthCheckType
+  List<String> groupMetrics
   List<String> terminationPolicies
 
 }

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/BasicAmazonDeployHandler.groovy
@@ -255,6 +255,7 @@ class BasicAmazonDeployHandler implements DeployHandler<BasicAmazonDeployDescrip
         classicLoadBalancers: loadBalancers.classicLoadBalancers,
         targetGroupArns: loadBalancers.targetGroupArns,
         cooldown: description.cooldown,
+        groupMetrics: description.groupMetrics,
         healthCheckGracePeriod: description.healthCheckGracePeriod,
         healthCheckType: description.healthCheckType,
         terminationPolicies: description.terminationPolicies,

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/handlers/MigrateServerGroupStrategy.java
@@ -159,6 +159,7 @@ public abstract class MigrateServerGroupStrategy implements MigrateStrategySuppo
       deployDescription.setKeyPair(keyPair != null ? keyPair : launchConfig.getKeyName());
       deployDescription.setAssociatePublicIpAddress(launchConfig.getAssociatePublicIpAddress());
       deployDescription.setCooldown(sourceGroup.getDefaultCooldown());
+      deployDescription.setGroupMetrics(sourceGroup.getGroupMetrics());
       deployDescription.setHealthCheckGracePeriod(sourceGroup.getHealthCheckGracePeriod());
       deployDescription.setHealthCheckType(sourceGroup.getHealthCheckType());
       deployDescription.setSuspendedProcesses(sourceGroup.getSuspendedProcesses().stream()

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/CopyLastAsgAtomicOperation.groovy
@@ -165,6 +165,7 @@ class CopyLastAsgAtomicOperation implements AtomicOperation<DeploymentResult> {
         newDescription.keyPair = description.keyPair ?: (sourceIsTarget ? ancestorLaunchConfiguration.keyName : description.credentials.defaultKeyPair)
         newDescription.associatePublicIpAddress = description.associatePublicIpAddress != null ? description.associatePublicIpAddress : ancestorLaunchConfiguration.associatePublicIpAddress
         newDescription.cooldown = description.cooldown != null ? description.cooldown : ancestorAsg.defaultCooldown
+        newDescription.groupMetrics = description.groupMetrics != null ? description.groupMetrics : ancestorAsg.groupMetrics
         newDescription.healthCheckGracePeriod = description.healthCheckGracePeriod != null ? description.healthCheckGracePeriod : ancestorAsg.healthCheckGracePeriod
         newDescription.healthCheckType = description.healthCheckType ?: ancestorAsg.healthCheckType
         newDescription.suspendedProcesses = description.suspendedProcesses != null ? description.suspendedProcesses : ancestorAsg.suspendedProcesses*.processName

--- a/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgAtomicOperation.groovy
+++ b/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/deploy/ops/ModifyAsgAtomicOperation.groovy
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.clouddriver.aws.deploy.ops
 
 import com.amazonaws.services.autoscaling.model.DescribeAutoScalingGroupsRequest
+import com.amazonaws.services.autoscaling.model.DisableMetricsCollectionRequest
+import com.amazonaws.services.autoscaling.model.EnableMetricsCollectionRequest
 import com.amazonaws.services.autoscaling.model.UpdateAutoScalingGroupRequest
 import com.netflix.spinnaker.clouddriver.aws.deploy.description.ModifyAsgDescription
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider
@@ -77,6 +79,14 @@ class ModifyAsgAtomicOperation implements AtomicOperation<Void> {
           .withHealthCheckGracePeriod(description.healthCheckGracePeriod)
           .withHealthCheckType(description.healthCheckType)
           .withTerminationPolicies(description.terminationPolicies)
+
+      if (description.groupMetrics) {
+         task.updateStatus BASE_PHASE, "Enabling Auto Scaling Group metrics for $asgName in $region..."
+         autoScaling.enableMetricsCollection(new EnableMetricsCollectionRequest().withAutoScalingGroupName(asgName))
+      } else {
+         task.updateStatus BASE_PHASE, "Disabling Auto Scaling Group metrics for $asgName in $region..."
+         autoScaling.disableMetricsCollection(new DisableMetricsCollectionRequest().withAutoScalingGroupName(asgName))
+      }
 
       autoScaling.updateAutoScalingGroup(updateRequest)
 


### PR DESCRIPTION
**NOTE**: This PR is just to get reviews from other Rapid7 developers.

Add clouddriver support for spinnaker/spinnaker#1548 and discussed in [#dev](https://spinnakerteam.slack.com/archives/C0DPVDMQE/p1491560544869926) in Slack.